### PR TITLE
Replace hardcoded yay with user-config aur wrapper for single install

### DIFF
--- a/contents/ui/PackageManager.qml
+++ b/contents/ui/PackageManager.qml
@@ -146,7 +146,7 @@ Item{
         }
         if( source === "FLATPAK" ) executable.exec(plasmoid.configuration.terminal+" "+konsoleFlags+" -e flatpak update "+name.split(" ").pop()+" && echo -en \"Finished updating.\n\"");
         else if( source === "SNAP" ) console.log("SNAP support coming soon!");
-        else if( source === "AUR" ) executable.exec(plasmoid.configuration.terminal+" "+konsoleFlags+" -e yay -S "+name+" && echo -en \"Finished updating.\n\"")
+        else if( source === "AUR" ) executable.exec(plasmoid.configuration.terminal+" "+konsoleFlags+" -e "+plasmoid.configuration.aurWrapper+" -S "+name+" && echo -en \"Finished updating.\n\"")
         else executable.exec(plasmoid.configuration.terminal+" "+konsoleFlags+" -e sudo pacman -S "+name+" && echo -en \"Finished updating.\n\"");
     }
     function showInfo(name, source) {


### PR DESCRIPTION
I only took a quick glance at the code, but it seems this was missed when switching from yay to a generic wrapper?