### PR TITLE
Add whitespace after "flatpak info" command

### DIFF
--- a/contents/ui/PackageManager.qml
+++ b/contents/ui/PackageManager.qml
@@ -124,7 +124,7 @@ Item{
 
     // Util function to fill details about a package
     function fillDetailsFor(name, source) {
-        if( source === "FLATPAK" ) executable.exec("flatpak info"+name.split(" ").pop());
+        if( source === "FLATPAK" ) executable.exec("flatpak info "+name.split(" ").pop());
         // else if( source === "SNAP" ) details = ["Not Supported","yet"];
         else executable.exec( "pacman -Qi " + name );
     }


### PR DESCRIPTION
Due to missing whitespace plasmoid tries to execute command containing Flatpak package name for example "flatpak infocom.valvesoftware.Steam"