### PR TITLE
FIX: Update not searching afterwards

### DIFF
--- a/contents/Util.js
+++ b/contents/Util.js
@@ -326,11 +326,19 @@ function execInTerminal( cmd, hold, searchAfter ) {
 ###############################################################################
 #############################    Process Ended    #############################
 ###############################################################################`
+
 	let termCmd  = cfg.terminal + ` -e bash -c 'trap "" SIGINT; echo "${startMessage}"; ${cmd} echo "${endMessage}";`
 	if( hold ) termCmd += `read -n 1 -p "Press Any Key to exit...";'`
 	else termCmd += `'`
+
 	packageManager.exec(termCmd,(_,_,stderr,_)=>{
 		console.log("errorlog:"+stderr);
-		if( searchAfter ) action_searchForUpdates();
+    if( searchAfter ) {
+      // seraching() was called in action_updateSystem which set isUpdating if
+      // stopSearch() is not called action_searchForUpdates() will early
+      // return and not perform a serach.
+      stopSearch()
+      action_searchForUpdates();
+    }
 	})
 }


### PR DESCRIPTION
Due to action_updateSystem() calling searching(), isUpdating gets set globally. At the end of action_updateSystem() execInTerminal() is used to perform the actual update.

execInTerminal() if passed true as it's last argument will call action_searchForUpdates() which will early return if isUpdating is already set to true.

Thus to make the search intended by the searchAfter argument of execInTerminal() happen stopSearch() needs to be called before calling action_searchForUpdates().